### PR TITLE
Unsupported link query operations return error and added exists

### DIFF
--- a/docs/QUERY.md
+++ b/docs/QUERY.md
@@ -296,6 +296,19 @@ links:
         value: "Uses"
 ```
 
+
+### Operator: `exists`
+
+Filter matches only links where the specified field exists. This is intended to be used with `attribute.*` fields but can be used with any field even fields that are mandatory where it has no effect.
+
+```yaml
+links:
+  filters:
+    - condition:
+        field: attribute.name
+        operator: exists
+```
+
 ### Operator: `and`
 
 Filter operation that allows multiple conditions to be combined together.  This is useful for more complex queries.

--- a/internal/query/execute.go
+++ b/internal/query/execute.go
@@ -119,6 +119,27 @@ func linkMatchesFilter(link configuration.Link, filter Filter) (bool, error) {
 		return fieldValue == filter.Condition.Value, nil
 	case "notEquals":
 		return fieldValue != filter.Condition.Value, nil
+	case "exists":
+		switch filter.Condition.Field {
+		case "source":
+			return link.Source != "", nil
+		case "target":
+			return link.Target != "", nil
+		case "type":
+			return link.Type != "", nil
+		default:
+			field := filter.Condition.Field
+
+			// Check in Attributes, if 'attribute.' prefix remove it and look up attribute
+			if len(field) > 10 && field[:10] == "attribute." {
+				field = field[10:]
+			} else {
+				return false, nil
+			}
+
+			_, exists := link.Attributes[field]
+			return exists, nil
+		}
 	case "and":
 		// Check if all conditions are met
 		for _, condition := range filter.Condition.Conditions {

--- a/internal/query/validate.go
+++ b/internal/query/validate.go
@@ -73,6 +73,8 @@ func (filter *Filter) Validate(filterType int) error {
 func (condition *Condition) validate(filterType int) error {
 	var err error
 
+	allowCommand := false
+
 	allowField := false
 	requireField := false
 
@@ -85,32 +87,41 @@ func (condition *Condition) validate(filterType int) error {
 	// Validate the operation is 'equals' using a switch so it is easy to add more operations later
 	switch condition.Operator {
 	case "equals":
+		allowCommand = true
 		requireField = true
 		requireValue = true
 
 	case "notEquals":
+		allowCommand = true
 		requireField = true
 		requireValue = true
 
 	case "exists":
+		allowCommand = true
 		requireField = true
 
 	case "and":
+		allowCommand = true
 		requireCondition = true
 
 	case "or":
+		allowCommand = true
 		requireCondition = true
 
 	case "ancestorOf":
+		allowCommand = filterType == NodeCondition
 		requireValue = true
 
 	case "descendantOf":
+		allowCommand = filterType == NodeCondition
 		requireValue = true
 
 	case "childOf":
+		allowCommand = filterType == NodeCondition
 		requireValue = true
 
 	case "parentOf":
+		allowCommand = filterType == NodeCondition
 		requireValue = true
 
 	default:
@@ -130,7 +141,9 @@ func (condition *Condition) validate(filterType int) error {
 		allowCondition = true
 	}
 
-	if requireField && condition.Field == "" {
+	if !allowCommand {
+		return fmt.Errorf("operator %s is not allowed", condition.Operator)
+	} else if requireField && condition.Field == "" {
 		return fmt.Errorf("field is required")
 	} else if !allowField && condition.Field != "" {
 		return fmt.Errorf("field is not allowed")

--- a/tests/complex/queries/link_exists/config.yaml
+++ b/tests/complex/queries/link_exists/config.yaml
@@ -1,0 +1,41 @@
+nodes:
+    - id: app_foo
+      type: Application
+      parent: cluster
+    - id: service_foo
+      type: Microservice
+      parent: app_foo
+      attributes:
+        language: Java
+        name: Foo Service
+    - id: app_bar
+      type: Application
+      parent: cluster
+    - id: service_bar
+      type: Microservice
+      parent: app_bar
+      attributes:
+        language: Go
+        name: Bar Service
+    - id: cluster
+      type: Infrastructure
+      attributes:
+        name: Container Hosting
+    - id: db_foo
+      type: Database
+      parent: app_foo
+      attributes:
+        database: Valkey
+        name: Foo Database
+    - id: db_bar
+      type: Database
+      parent: app_bar
+      attributes:
+        database: MariaDB
+        name: Bar Database
+links:
+    - source: service_foo
+      target: service_bar
+      type: Uses
+      attributes:
+        payload: example

--- a/tests/complex/queries/link_exists/mermaid.mmd
+++ b/tests/complex/queries/link_exists/mermaid.mmd
@@ -1,0 +1,12 @@
+flowchart TD
+    %% Nodes
+    app_bar
+    app_foo
+    cluster
+    db_bar
+    db_foo
+    service_bar
+    service_foo
+
+    %% Links
+    service_foo -->|Uses| service_bar

--- a/tests/complex/queries/link_exists/mermaid.yaml
+++ b/tests/complex/queries/link_exists/mermaid.yaml
@@ -1,0 +1,1 @@
+direction: "TD"

--- a/tests/complex/queries/link_exists/query.yaml
+++ b/tests/complex/queries/link_exists/query.yaml
@@ -1,0 +1,5 @@
+links:
+  filters:
+    - condition:
+        field: attribute.payload
+        operator: exists


### PR DESCRIPTION
The link queries didn't support all of the operations and was failing but returning an incorrect error.  Those operations now explicitely failing.

But as a result the exists operation that can work was added so it works with the corresponding test case