### PR TITLE
Add validation tests for various invalid configurations in YAMLtecture

### DIFF
--- a/.clip4llm
+++ b/.clip4llm
@@ -1,1 +1,1 @@
-exclude=LICENSE,tests
+exclude=LICENSE

--- a/tests/invalid/config/empty_link_attribute_key/expected_error.txt
+++ b/tests/invalid/config/empty_link_attribute_key/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating configuration
+link at index 0 is invalid: attribute.key cannot be empty

--- a/tests/invalid/config/empty_link_attribute_key/input.yaml
+++ b/tests/invalid/config/empty_link_attribute_key/input.yaml
@@ -1,0 +1,11 @@
+nodes:
+  - id: node_a
+    type: Service
+  - id: node_b
+    type: Service
+links:
+  - source: node_a
+    target: node_b
+    type: API
+    attributes:
+      "": "value" # Empty Attribute Key

--- a/tests/invalid/config/empty_link_attribute_value/expected_error.txt
+++ b/tests/invalid/config/empty_link_attribute_value/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating configuration
+link at index 0 is invalid: attribute.value cannot be empty

--- a/tests/invalid/config/empty_link_attribute_value/input.yaml
+++ b/tests/invalid/config/empty_link_attribute_value/input.yaml
@@ -1,0 +1,11 @@
+nodes:
+  - id: node_a
+    type: Service
+  - id: node_b
+    type: Service
+links:
+  - source: node_a
+    target: node_b
+    type: API
+    attributes:
+      key: "" # Empty Attribute Value

--- a/tests/invalid/config/empty_link_source/expected_error.txt
+++ b/tests/invalid/config/empty_link_source/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating configuration
+link at index 0 is invalid: link.source cannot be empty

--- a/tests/invalid/config/empty_link_source/input.yaml
+++ b/tests/invalid/config/empty_link_source/input.yaml
@@ -1,0 +1,9 @@
+nodes:
+  - id: node_a
+    type: Service
+  - id: node_b
+    type: Service
+links:
+  - source: "" # Empty Source
+    target: node_b
+    type: API

--- a/tests/invalid/config/empty_link_target/expected_error.txt
+++ b/tests/invalid/config/empty_link_target/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating configuration
+link at index 0 is invalid: link.target cannot be empty

--- a/tests/invalid/config/empty_link_target/input.yaml
+++ b/tests/invalid/config/empty_link_target/input.yaml
@@ -1,0 +1,9 @@
+nodes:
+  - id: node_a
+    type: Service
+  - id: node_b
+    type: Service
+links:
+  - source: node_a
+    target: "" # Empty Target
+    type: API

--- a/tests/invalid/config/empty_link_type/expected_error.txt
+++ b/tests/invalid/config/empty_link_type/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating configuration
+link at index 0 is invalid: link.type cannot be empty

--- a/tests/invalid/config/empty_link_type/input.yaml
+++ b/tests/invalid/config/empty_link_type/input.yaml
@@ -1,0 +1,9 @@
+nodes:
+  - id: node_a
+    type: Service
+  - id: node_b
+    type: Service
+links:
+  - source: node_a
+    target: node_b
+    type: "" # Empty Type

--- a/tests/invalid/config/empty_node_attribute_key/expected_error.txt
+++ b/tests/invalid/config/empty_node_attribute_key/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating configuration
+node 'node_a' is invalid: attribute.key cannot be empty

--- a/tests/invalid/config/empty_node_attribute_key/input.yaml
+++ b/tests/invalid/config/empty_node_attribute_key/input.yaml
@@ -1,0 +1,6 @@
+nodes:
+  - id: node_a
+    type: Service
+    attributes:
+      "": "value" # Empty Attribute Key
+links: []

--- a/tests/invalid/config/empty_node_attribute_value/expected_error.txt
+++ b/tests/invalid/config/empty_node_attribute_value/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating configuration
+node 'node_a' is invalid: attribute.value cannot be empty

--- a/tests/invalid/config/empty_node_attribute_value/input.yaml
+++ b/tests/invalid/config/empty_node_attribute_value/input.yaml
@@ -1,0 +1,6 @@
+nodes:
+  - id: node_a
+    type: Service
+    attributes:
+      key: "" # Empty Attribute Value
+links: []

--- a/tests/invalid/config/empty_node_id/expected_error.txt
+++ b/tests/invalid/config/empty_node_id/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating configuration
+node '' is invalid: node.id cannot be empty

--- a/tests/invalid/config/empty_node_id/input.yaml
+++ b/tests/invalid/config/empty_node_id/input.yaml
@@ -1,0 +1,4 @@
+nodes:
+  - id: "" # Empty ID
+    type: Service
+links: []

--- a/tests/invalid/config/empty_node_type/expected_error.txt
+++ b/tests/invalid/config/empty_node_type/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating configuration
+node 'node_a' is invalid: node.type cannot be empty

--- a/tests/invalid/config/empty_node_type/input.yaml
+++ b/tests/invalid/config/empty_node_type/input.yaml
@@ -1,0 +1,4 @@
+nodes:
+  - id: node_a
+    type: "" # Empty Type
+links: []

--- a/tests/invalid/config/nonexistent_link_source/expected_error.txt
+++ b/tests/invalid/config/nonexistent_link_source/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating configuration
+link has non-existent source node 'node_nonexistent'

--- a/tests/invalid/config/nonexistent_link_source/input.yaml
+++ b/tests/invalid/config/nonexistent_link_source/input.yaml
@@ -1,0 +1,7 @@
+nodes:
+  - id: node_b
+    type: Service
+links:
+  - source: node_nonexistent # Non-existent Source
+    target: node_b
+    type: API

--- a/tests/invalid/config/nonexistent_link_target/expected_error.txt
+++ b/tests/invalid/config/nonexistent_link_target/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating configuration
+link has non-existent target node 'node_nonexistent'

--- a/tests/invalid/config/nonexistent_link_target/input.yaml
+++ b/tests/invalid/config/nonexistent_link_target/input.yaml
@@ -1,0 +1,7 @@
+nodes:
+  - id: node_a
+    type: Service
+links:
+  - source: node_a
+    target: node_nonexistent # Non-existent Target
+    type: API

--- a/tests/invalid/config/nonexistent_parent/expected_error.txt
+++ b/tests/invalid/config/nonexistent_parent/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating configuration
+node 'node_a' has non-existent parent 'node_nonexistent'

--- a/tests/invalid/config/nonexistent_parent/input.yaml
+++ b/tests/invalid/config/nonexistent_parent/input.yaml
@@ -1,0 +1,5 @@
+nodes:
+  - id: node_a
+    type: Service
+    parent: node_nonexistent # Non-existent Parent
+links: []

--- a/tests/invalid/mermaid/invalid_link_style_filter_query/expected_error.txt
+++ b/tests/invalid/mermaid/invalid_link_style_filter_query/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating mermaid
+invalid operator: invalid_op

--- a/tests/invalid/mermaid/invalid_link_style_filter_query/input.yaml
+++ b/tests/invalid/mermaid/invalid_link_style_filter_query/input.yaml
@@ -1,0 +1,8 @@
+linkStyles:
+  - filters:
+      - condition:
+          operator: invalid_op # Invalid query operator
+          field: type
+          value: "API"
+    format:
+      stroke: "#f00000"

--- a/tests/invalid/mermaid/invalid_link_style_format_color/expected_error.txt
+++ b/tests/invalid/mermaid/invalid_link_style_format_color/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating mermaid
+invalid color for stroke: not_a_color

--- a/tests/invalid/mermaid/invalid_link_style_format_color/input.yaml
+++ b/tests/invalid/mermaid/invalid_link_style_format_color/input.yaml
@@ -1,0 +1,8 @@
+linkStyles:
+  - filters:
+      - condition:
+          field: type
+          operator: equals
+          value: "API"
+    format:
+      stroke: "not_a_color" # Invalid color

--- a/tests/invalid/mermaid/invalid_link_style_format_pixel/expected_error.txt
+++ b/tests/invalid/mermaid/invalid_link_style_format_pixel/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating mermaid
+invalid pixel for stroke-width: thick

--- a/tests/invalid/mermaid/invalid_link_style_format_pixel/input.yaml
+++ b/tests/invalid/mermaid/invalid_link_style_format_pixel/input.yaml
@@ -1,0 +1,8 @@
+linkStyles:
+  - filters:
+      - condition:
+          field: type
+          operator: equals
+          value: "API"
+    format:
+      stroke-width: "thick" # Invalid pixel value

--- a/tests/invalid/mermaid/invalid_node_style_filter_query/expected_error.txt
+++ b/tests/invalid/mermaid/invalid_node_style_filter_query/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating mermaid
+invalid operator: invalid_op

--- a/tests/invalid/mermaid/invalid_node_style_filter_query/input.yaml
+++ b/tests/invalid/mermaid/invalid_node_style_filter_query/input.yaml
@@ -1,0 +1,8 @@
+nodeStyles:
+  - filters:
+      - condition:
+          operator: invalid_op # Invalid query operator
+          field: type
+          value: "Database"
+    format:
+      fill: "#f9f9f9"

--- a/tests/invalid/mermaid/invalid_node_style_format_color/expected_error.txt
+++ b/tests/invalid/mermaid/invalid_node_style_format_color/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating mermaid
+invalid color for fill: not_a_color

--- a/tests/invalid/mermaid/invalid_node_style_format_color/input.yaml
+++ b/tests/invalid/mermaid/invalid_node_style_format_color/input.yaml
@@ -1,0 +1,8 @@
+nodeStyles:
+  - filters:
+      - condition:
+          field: type
+          operator: equals
+          value: "Database"
+    format:
+      fill: "not_a_color" # Invalid color

--- a/tests/invalid/mermaid/invalid_node_style_format_pixel/expected_error.txt
+++ b/tests/invalid/mermaid/invalid_node_style_format_pixel/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating mermaid
+invalid pixel for stroke-width: 2em

--- a/tests/invalid/mermaid/invalid_node_style_format_pixel/input.yaml
+++ b/tests/invalid/mermaid/invalid_node_style_format_pixel/input.yaml
@@ -1,0 +1,8 @@
+nodeStyles:
+  - filters:
+      - condition:
+          field: type
+          operator: equals
+          value: "Database"
+    format:
+      stroke-width: "2em" # Invalid pixel value

--- a/tests/invalid/mermaid/links_no_format/expected_error.txt
+++ b/tests/invalid/mermaid/links_no_format/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating mermaid
+at least one 'format' attribute must be set

--- a/tests/invalid/mermaid/links_no_format/input.yaml
+++ b/tests/invalid/mermaid/links_no_format/input.yaml
@@ -1,0 +1,7 @@
+linkStyles:
+  - filters:
+      - condition:
+          field: type
+          operator: equals
+          value: "Database"
+    # Missing format block

--- a/tests/invalid/query/disallowed_condition/expected_error.txt
+++ b/tests/invalid/query/disallowed_condition/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating query
+condition is not allowed

--- a/tests/invalid/query/disallowed_condition/input.yaml
+++ b/tests/invalid/query/disallowed_condition/input.yaml
@@ -1,0 +1,9 @@
+nodes:
+  filters:
+    - condition:
+        operator: equals # Does not allow conditions
+        field: type
+        value: "Microservice"
+        conditions:
+          - field: attribute.name
+            operator: exists

--- a/tests/invalid/query/disallowed_field/expected_error.txt
+++ b/tests/invalid/query/disallowed_field/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating query
+field is not allowed

--- a/tests/invalid/query/disallowed_field/input.yaml
+++ b/tests/invalid/query/disallowed_field/input.yaml
@@ -1,0 +1,6 @@
+nodes:
+  filters:
+    - condition:
+        operator: ancestorOf # Does not allow field
+        field: type
+        value: "some_node"

--- a/tests/invalid/query/disallowed_value/expected_error.txt
+++ b/tests/invalid/query/disallowed_value/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating query
+value is not allowed

--- a/tests/invalid/query/disallowed_value/input.yaml
+++ b/tests/invalid/query/disallowed_value/input.yaml
@@ -1,0 +1,6 @@
+nodes:
+  filters:
+    - condition:
+        operator: exists # Does not allow value
+        field: attribute.name
+        value: "present"

--- a/tests/invalid/query/empty_attribute_key/expected_error.txt
+++ b/tests/invalid/query/empty_attribute_key/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating query
+invalid field: attribute.

--- a/tests/invalid/query/empty_attribute_key/input.yaml
+++ b/tests/invalid/query/empty_attribute_key/input.yaml
@@ -1,0 +1,5 @@
+nodes:
+  filters:
+    - condition:
+        field: "attribute." # Empty attribute key part
+        operator: exists

--- a/tests/invalid/query/empty_value/expected_error.txt
+++ b/tests/invalid/query/empty_value/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating query
+value is required

--- a/tests/invalid/query/empty_value/input.yaml
+++ b/tests/invalid/query/empty_value/input.yaml
@@ -1,0 +1,6 @@
+nodes:
+  filters:
+    - condition:
+        field: type
+        operator: equals
+        value: "" # Empty value

--- a/tests/invalid/query/invalid_link_field/expected_error.txt
+++ b/tests/invalid/query/invalid_link_field/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating query
+field 'parent' is not allowed

--- a/tests/invalid/query/invalid_link_field/input.yaml
+++ b/tests/invalid/query/invalid_link_field/input.yaml
@@ -1,0 +1,6 @@
+links:
+  filters:
+    - condition:
+        operator: equals
+        field: parent # Invalid field for Link filters
+        value: "some_parent"

--- a/tests/invalid/query/invalid_nested_condition/expected_error.txt
+++ b/tests/invalid/query/invalid_nested_condition/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating query
+field is required

--- a/tests/invalid/query/invalid_nested_condition/input.yaml
+++ b/tests/invalid/query/invalid_nested_condition/input.yaml
@@ -1,0 +1,10 @@
+nodes:
+  filters:
+    - condition:
+        operator: and
+        conditions:
+          - field: type
+            operator: equals
+            value: "Microservice"
+          - operator: equals # Nested condition requires field
+            value: "Java"

--- a/tests/invalid/query/invalid_node_field/expected_error.txt
+++ b/tests/invalid/query/invalid_node_field/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating query
+field 'source' is not allowed

--- a/tests/invalid/query/invalid_node_field/input.yaml
+++ b/tests/invalid/query/invalid_node_field/input.yaml
@@ -1,0 +1,6 @@
+nodes:
+  filters:
+    - condition:
+        operator: equals
+        field: source # Invalid field for Node filters
+        value: "some_source"

--- a/tests/invalid/query/missing_required_condition/expected_error.txt
+++ b/tests/invalid/query/missing_required_condition/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating query
+condition is required

--- a/tests/invalid/query/missing_required_condition/input.yaml
+++ b/tests/invalid/query/missing_required_condition/input.yaml
@@ -1,0 +1,4 @@
+nodes:
+  filters:
+    - condition:
+        operator: and # Requires conditions

--- a/tests/invalid/query/missing_required_field/expected_error.txt
+++ b/tests/invalid/query/missing_required_field/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating query
+field is required

--- a/tests/invalid/query/missing_required_field/input.yaml
+++ b/tests/invalid/query/missing_required_field/input.yaml
@@ -1,0 +1,5 @@
+nodes:
+  filters:
+    - condition:
+        operator: equals # Requires field
+        value: "Microservice"

--- a/tests/invalid/query/missing_required_value/expected_error.txt
+++ b/tests/invalid/query/missing_required_value/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating query
+value is required

--- a/tests/invalid/query/missing_required_value/input.yaml
+++ b/tests/invalid/query/missing_required_value/input.yaml
@@ -1,0 +1,5 @@
+nodes:
+  filters:
+    - condition:
+        field: type
+        operator: equals # Requires value

--- a/tests/invalid/query/operator_not_allowed_for_type/expected_error.txt
+++ b/tests/invalid/query/operator_not_allowed_for_type/expected_error.txt
@@ -1,0 +1,3 @@
+YAMLtecture
+Error: Error validating query
+operator parentOf is not allowed

--- a/tests/invalid/query/operator_not_allowed_for_type/input.yaml
+++ b/tests/invalid/query/operator_not_allowed_for_type/input.yaml
@@ -1,0 +1,6 @@
+# parentOf is only allowed for Node filters
+links:
+  filters:
+    - condition:
+        operator: parentOf
+        value: "some_node"


### PR DESCRIPTION
- Updated exclusion list in .clip4llm to remove tests directory.
- Added test cases for invalid link configurations:
  - Empty attribute key and value
  - Empty source and target
  - Non-existent source and target nodes
  - Invalid link types
- Added test cases for invalid node configurations:
  - Empty attribute key and value
  - Empty node ID and type
  - Non-existent parent node
- Added tests for invalid Mermaid configurations:
  - Invalid link style filter queries
  - Invalid link style format colors and pixels
  - Missing format attributes
- Added tests for invalid query configurations:
  - Disallowed conditions, fields, and values
  - Missing required conditions, fields, and values
  - Invalid nested conditions
  - Invalid link fields
  - Operators not allowed for specific types