### PR TITLE
Enhance test to validate LoadFolder matches the output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/UnitVectorY-Labs/YAMLtecture
 go 1.24.2 // GOVERSION
 
 require (
+	github.com/UnitVectorY-Labs/yamlequal v0.0.1
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/google/uuid v1.6.0
 	golang.org/x/term v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/UnitVectorY-Labs/yamlequal v0.0.1 h1:eRX4EK8khbWynTM9xiwd9GYZ+fGJt01EodW0KY02cv8=
+github.com/UnitVectorY-Labs/yamlequal v0.0.1/go.mod h1:bAiUu8ugq/u6qi/Vb8Nyl+V2PmQeqL9HOC8hs1+C9Os=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/UnitVectorY-Labs/yamlequal"
 )
 
 func TestLoadYAMLFiles(t *testing.T) {
@@ -13,7 +15,61 @@ func TestLoadYAMLFiles(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if info.Name() == "config.yaml" {
+
+		if info.Name() == "configs" && info.IsDir() {
+
+			relDir, err := filepath.Rel("../../tests", filepath.Dir(path))
+			if err != nil {
+				return err
+			}
+
+			sanitizedRelDir := strings.ReplaceAll(relDir, string(filepath.Separator), "#") + "#configs"
+
+			// Log the paths for debugging
+			log.Printf("Relative Directory: %s", relDir)
+			log.Printf("Sanitized Relative Directory: %s", sanitizedRelDir)
+
+			// Get the parent directory of 'path'
+			parentDir := filepath.Dir(path)
+			configPath := filepath.Join(parentDir, "config.yaml")
+
+			// If config path does not exist, skip this iteration
+			if _, err := os.Stat(configPath); os.IsNotExist(err) {
+				log.Printf("Skipping %s as config.yaml does not exist", sanitizedRelDir)
+				return nil
+			}
+
+			t.Run(sanitizedRelDir, func(t *testing.T) {
+
+				folderConfig, err := LoadFolder(path)
+				if err != nil {
+					t.Errorf("Failed to load folder %s: %v", path, err)
+					return
+				}
+
+				folderConfigBytes := []byte(folderConfig.YamlString())
+
+				config, err := LoadConfig(configPath)
+				if err != nil {
+					t.Errorf("Failed to load %s: %v", path, err)
+					return
+				}
+
+				configBytes := []byte(config.YamlString())
+
+				// Compare two YAML content strings directly
+				equal, diff, err := yamlequal.CompareYAML(folderConfigBytes, configBytes)
+				if err != nil {
+					t.Error("Error comparing files.", err)
+					return
+				}
+
+				if !equal {
+					t.Errorf("Files are not the same:\n%s", diff)
+					return
+				}
+			})
+		} else if info.Name() == "config.yaml" {
 
 			relDir, err := filepath.Rel("../../tests", filepath.Dir(path))
 			if err != nil {


### PR DESCRIPTION
This requires the use of yamlequal to verify that the generated file is equal to the expected file