### PR TITLE
Update Go version to 1.25.1

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.0' # GOVERSION
+          go-version: '1.25.1' # GOVERSION
 
       - name: Cache Go modules
         uses: actions/cache@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UnitVectorY-Labs/YAMLtecture
 
-go 1.25.0 // GOVERSION
+go 1.25.1 // GOVERSION
 
 require (
 	github.com/UnitVectorY-Labs/yamlequal v0.0.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded the Go toolchain to version 1.25.1 across project configuration and continuous integration to align environments.
  - Incorporates the latest patch-level fixes for improved stability, security, and compatibility with dependencies.
  - Standardizes version pinning to reduce build variability and ensure consistent, reproducible builds.
  - No user-facing changes; behavior and interfaces remain unchanged.
  - Existing workflows continue to function without action required from users or integrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->