### PR TITLE
fix: correct semgrep GitHub action workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,36 +1,31 @@
 name: Semgrep
 
 on:
-  pull_request: {}
-  workflow_dispatch: {}
+  pull_request:
   push:
-    branches:
-      - main
-      - master
-    paths:
-      - .github/workflows/semgrep.yml
-  schedule:
-    - cron: '20 17 * * *'
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   semgrep:
-    name: semgrep/ci
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep@sha256:65dcd4408adda7c183a6b4550cb1e9b19f7f627a6fbb7e0559bd466bedc44d7b
+      image: semgrep/semgrep@sha256:65dcd4408adda7c183a6b4550cb1e9b19f7f627a6fbb7e0559bd466bedc44d7b # v1.172.0
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - run: semgrep scan --config auto --sarif --output semgrep.sarif
-        env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      - name: Scan
+        run: semgrep scan --config auto --sarif --output semgrep.sarif
 
-      - name: Upload Semgrep results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+      - name: Upload findings to GitHub
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: semgrep.sarif
-
+          category: semgrep


### PR DESCRIPTION
Replace broken semgrep workflow with correct version matching ghscanscope template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Semgrep scans now run for pull requests, pushes to `main`, and manual workflow runs.
  * Security scan results are uploaded with improved workflow reliability and version consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->